### PR TITLE
Add support for HEVC video codec

### DIFF
--- a/streamer/bitrate_configuration.py
+++ b/streamer/bitrate_configuration.py
@@ -87,6 +87,12 @@ class VideoCodec(enum.Enum):
 
   AV1 = 'av1'
   """AV1."""
+  
+  HEVC = 'hevc'
+  """HEVC, also known as h.265"""
+
+  HARDWARE_HEVC = 'hw:hevc'
+  """HEVC, with hardware encoding"""
 
   def is_hardware_accelerated(self) -> bool:
     """Returns True if this codec is hardware accelerated."""
@@ -114,7 +120,7 @@ class VideoCodec(enum.Enum):
     # TODO(#31): add support for configurable output format per-codec
     if self.get_base_codec() == VideoCodec.VP9:
       return 'webm'
-    elif self.get_base_codec() == VideoCodec.H264:
+    elif self.get_base_codec() in {VideoCodec.H264, VideoCodec.HEVC}:
       return 'mp4'
     elif self.get_base_codec() == VideoCodec.AV1:
       return 'mp4'
@@ -218,6 +224,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '108k',
       'vp9': '96k',
+      'hevc': '96k',
       'av1': '72k',
     },
   }),
@@ -227,6 +234,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '242k',
       'vp9': '151k',
+      'hevc': '151k',
       'av1': '114k',
     },
   }),
@@ -236,6 +244,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '400k',
       'vp9': '277k',
+      'hevc': '277k',
       'av1': '210k',
     },
   }),
@@ -245,6 +254,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '1M',
       'vp9': '512k',
+      'hevc': '512k',
       'av1': '389k',
     },
   }),
@@ -254,6 +264,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '1.5M',
       'vp9': '768k',
+      'hevc': '768k',
       'av1': '450k',
     },
   }),
@@ -264,6 +275,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '2M',
       'vp9': '1M',
+      'hevc': '1M',
       'av1': '512k',
     },
   }),
@@ -273,6 +285,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '3M',
       'vp9': '2M',
+      'hevc': '2M',
       'av1': '778k',
     },
   }),
@@ -283,6 +296,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '4M',
       'vp9': '2M',
+      'hevc': '2M',
       'av1': '850k',
     },
   }),
@@ -292,6 +306,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '5M',
       'vp9': '3M',
+      'hevc': '3M',
       'av1': '1M',
     },
   }),
@@ -302,6 +317,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '9M',
       'vp9': '6M',
+      'hevc': '6M',
       'av1': '3.5M',
     },
   }),
@@ -311,6 +327,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '14M',
       'vp9': '9M',
+      'hevc': '9M',
       'av1': '5M',
     },
   }),
@@ -321,6 +338,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '17M',
       'vp9': '12M',
+      'hevc': '12M',
       'av1': '6M',
     },
   }),
@@ -330,6 +348,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '25M',
       'vp9': '18M',
+      'hevc': '18M',
       'av1': '9M',
     },
   }),
@@ -340,6 +359,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '40M',
       'vp9': '24M',
+      'hevc': '24M',
       'av1': '12M',
     },
   }),
@@ -349,6 +369,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
     'bitrates': {
       'h264': '60M',
       'vp9': '36M',
+      'hevc': '36M',
       'av1': '18M',
     },
   }),

--- a/streamer/bitrate_configuration.py
+++ b/streamer/bitrate_configuration.py
@@ -221,6 +221,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '144p': VideoResolution({
     'max_width': 256,
     'max_height': 144,
+    'max_frame_rate': 30,
     'bitrates': {
       'h264': '108k',
       'vp9': '96k',
@@ -231,6 +232,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '240p': VideoResolution({
     'max_width': 426,
     'max_height': 240,
+    'max_frame_rate': 30,
     'bitrates': {
       'h264': '242k',
       'vp9': '151k',
@@ -241,6 +243,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '360p': VideoResolution({
     'max_width': 640,
     'max_height': 360,
+    'max_frame_rate': 30,
     'bitrates': {
       'h264': '400k',
       'vp9': '277k',
@@ -251,6 +254,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '480p': VideoResolution({  # NTSC analog broadcast TV resolution
     'max_width': 854,
     'max_height': 480,
+    'max_frame_rate': 30,
     'bitrates': {
       'h264': '1M',
       'vp9': '512k',
@@ -261,6 +265,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '576p': VideoResolution({  # PAL analog broadcast TV resolution
     'max_width': 1024,
     'max_height': 576,
+    'max_frame_rate': 30,
     'bitrates': {
       'h264': '1.5M',
       'vp9': '768k',
@@ -282,6 +287,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '720p-hfr': VideoResolution({
     'max_width': 1280,
     'max_height': 720,
+    'max_frame_rate': 60,
     'bitrates': {
       'h264': '3M',
       'vp9': '2M',
@@ -303,6 +309,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '1080p-hfr': VideoResolution({
     'max_width': 1920,
     'max_height': 1080,
+    'max_frame_rate': 60,
     'bitrates': {
       'h264': '5M',
       'vp9': '3M',
@@ -324,6 +331,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '1440p-hfr': VideoResolution({
     'max_width': 2560,
     'max_height': 1440,
+    'max_frame_rate': 60,
     'bitrates': {
       'h264': '14M',
       'vp9': '9M',
@@ -345,6 +353,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '4k-hfr': VideoResolution({
     'max_width': 4096,
     'max_height': 2160,
+    'max_frame_rate': 60,
     'bitrates': {
       'h264': '25M',
       'vp9': '18M',
@@ -366,6 +375,7 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '8k-hfr': VideoResolution({
     'max_width': 8192,
     'max_height': 4320,
+    'max_frame_rate': 60,
     'bitrates': {
       'h264': '60M',
       'vp9': '36M',

--- a/streamer/bitrate_configuration.py
+++ b/streamer/bitrate_configuration.py
@@ -221,7 +221,6 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '144p': VideoResolution({
     'max_width': 256,
     'max_height': 144,
-    'max_frame_rate': 30,
     'bitrates': {
       'h264': '108k',
       'vp9': '96k',
@@ -232,7 +231,6 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '240p': VideoResolution({
     'max_width': 426,
     'max_height': 240,
-    'max_frame_rate': 30,
     'bitrates': {
       'h264': '242k',
       'vp9': '151k',
@@ -243,7 +241,6 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '360p': VideoResolution({
     'max_width': 640,
     'max_height': 360,
-    'max_frame_rate': 30,
     'bitrates': {
       'h264': '400k',
       'vp9': '277k',
@@ -254,7 +251,6 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '480p': VideoResolution({  # NTSC analog broadcast TV resolution
     'max_width': 854,
     'max_height': 480,
-    'max_frame_rate': 30,
     'bitrates': {
       'h264': '1M',
       'vp9': '512k',
@@ -265,7 +261,6 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '576p': VideoResolution({  # PAL analog broadcast TV resolution
     'max_width': 1024,
     'max_height': 576,
-    'max_frame_rate': 30,
     'bitrates': {
       'h264': '1.5M',
       'vp9': '768k',
@@ -287,7 +282,6 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '720p-hfr': VideoResolution({
     'max_width': 1280,
     'max_height': 720,
-    'max_frame_rate': 60,
     'bitrates': {
       'h264': '3M',
       'vp9': '2M',
@@ -309,7 +303,6 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '1080p-hfr': VideoResolution({
     'max_width': 1920,
     'max_height': 1080,
-    'max_frame_rate': 60,
     'bitrates': {
       'h264': '5M',
       'vp9': '3M',
@@ -331,7 +324,6 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '1440p-hfr': VideoResolution({
     'max_width': 2560,
     'max_height': 1440,
-    'max_frame_rate': 60,
     'bitrates': {
       'h264': '14M',
       'vp9': '9M',
@@ -353,7 +345,6 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '4k-hfr': VideoResolution({
     'max_width': 4096,
     'max_height': 2160,
-    'max_frame_rate': 60,
     'bitrates': {
       'h264': '25M',
       'vp9': '18M',
@@ -375,7 +366,6 @@ DEFAULT_VIDEO_RESOLUTIONS = {
   '8k-hfr': VideoResolution({
     'max_width': 8192,
     'max_height': 4320,
-    'max_frame_rate': 60,
     'bitrates': {
       'h264': '60M',
       'vp9': '36M',

--- a/streamer/transcoder_node.py
+++ b/streamer/transcoder_node.py
@@ -202,9 +202,6 @@ class TranscoderNode(PolitelyWaitOnFinish):
       filters.append('pp=fd')
       args.extend(['-r', str(input.frame_rate)])
 
-    if stream.resolution.max_frame_rate < input.frame_rate:
-       args.extend(['-r', str(stream.resolution.max_frame_rate)])
-
     filters.extend(input.filters)
 
     hwaccel_api = self._pipeline_config.hwaccel_api

--- a/streamer/transcoder_node.py
+++ b/streamer/transcoder_node.py
@@ -224,7 +224,7 @@ class TranscoderNode(PolitelyWaitOnFinish):
     # https://github.com/google/shaka-streamer/issues/36
     filters.append('setsar=1:1')
 
-    if stream.codec == VideoCodec.H264:
+    if stream.codec in {VideoCodec.H264, VideoCodec.HEVC}:
       # These presets are specifically recognized by the software encoder.
       if self._pipeline_config.streaming_mode == StreamingMode.LIVE:
         args += [
@@ -248,15 +248,20 @@ class TranscoderNode(PolitelyWaitOnFinish):
         profile = 'main'
 
       args += [
-          # The only format supported by QT/Apple.
-          '-pix_fmt', 'yuv420p',
-          # Require a closed GOP.  Some decoders don't support open GOPs.
-          '-flags', '+cgop',
           # Set the H264 profile.  Without this, the default would be "main".
           # Note that this gets overridden to "baseline" in live streams by the
           # "-preset ultrafast" option, presumably because the baseline encoder
           # is faster.
           '-profile:v', profile,
+      ]
+      
+    if stream.codec.get_base_codec() in {VideoCodec.H264, VideoCodec.HEVC}:
+      args += [
+          # The only format supported by QT/Apple.
+          '-pix_fmt', 'yuv420p',
+          # Require a closed GOP.  Some decoders don't support open GOPs.
+          '-flags', '+cgop',
+         
       ]
 
     elif stream.codec.get_base_codec() == VideoCodec.VP9:

--- a/streamer/transcoder_node.py
+++ b/streamer/transcoder_node.py
@@ -202,6 +202,9 @@ class TranscoderNode(PolitelyWaitOnFinish):
       filters.append('pp=fd')
       args.extend(['-r', str(input.frame_rate)])
 
+    if stream.resolution.max_frame_rate < input.frame_rate:
+       args.extend(['-r', str(stream.resolution.max_frame_rate)])
+
     filters.extend(input.filters)
 
     hwaccel_api = self._pipeline_config.hwaccel_api


### PR DESCRIPTION
Using same FFmpeg parameters as h264 for the most part but letting the encoder choose profile and level automatically.
Bitrate settings mirror vp9

tested on macOS 10.15.7 and Ubuntu 20.04 LTS (FFmpeg 4.4)