### PR TITLE
Restrict WebM formats to DASH protocol

### DIFF
--- a/streamer/output_stream.py
+++ b/streamer/output_stream.py
@@ -56,6 +56,10 @@ class OutputStream(object):
     assert self.codec is not None
     return self.codec.get_ffmpeg_codec_string(hwaccel_api)
 
+  def is_dash_only(self) -> bool:
+    """Returns True if the output format is restricted to DASH protocol"""
+    assert self.codec is not None
+    return self.codec.get_output_format() is 'webm'
 
 class AudioOutputStream(OutputStream):
 
@@ -140,4 +144,3 @@ class TextOutputStream(OutputStream):
       'language': input.language,
       'format': 'mp4',
     }
-

--- a/streamer/packager_node.py
+++ b/streamer/packager_node.py
@@ -151,6 +151,9 @@ class PackagerNode(node_base.PolitelyWaitOnFinish):
           SINGLE_SEGMENT[stream.type],
           dir=self._segment_dir)
 
+    if stream.is_dash_only():
+      dict['dash_only'] = str(1)
+
     # The format of this argument to Shaka Packager is a single string of
     # key=value pairs separated by commas.
     return ','.join(key + '=' + value for key, value in dict.items())

--- a/streamer/packager_node.py
+++ b/streamer/packager_node.py
@@ -152,7 +152,7 @@ class PackagerNode(node_base.PolitelyWaitOnFinish):
           dir=self._segment_dir)
 
     if stream.is_dash_only():
-      dict['dash_only'] = str(1)
+      dict['dash_only'] = '1'
 
     # The format of this argument to Shaka Packager is a single string of
     # key=value pairs separated by commas.

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -582,6 +582,34 @@ function codecTests(manifestUrl, format) {
     const videoCodecList = trackList.map(track => track.videoCodec);
     expect(videoCodecList).toEqual(['av01.0.00M.08']);
   });
+
+  it('appropriately filters WebM formats ' + format, async () => {
+    const inputConfigDict = {
+      'inputs': [
+        {
+          'name': TEST_DIR + 'Sintel.2010.720p.Small.mkv',
+          'media_type': 'audio',
+          // Keep this test short by only encoding 1s of content.
+          'end_time': '0:01',
+        },
+      ],
+    };
+    const pipelineConfigDict = {
+      'streaming_mode': 'vod',
+      'resolutions': [],
+      'audio_codecs': ['aac', 'opus'],
+    };
+    await startStreamer(inputConfigDict, pipelineConfigDict);
+    await player.load(manifestUrl);
+
+    const trackList = player.getVariantTracks();
+    const audioCodecList = trackList.map(track => track.audioCodec);
+    if (manifestUrl == hlsManifestUrl) {
+      expect(audioCodecList).toEqual(['mp4a.40.2']);
+    } else if (manifestUrl == dashManifestUrl) {
+      expect(audioCodecList).toEqual(['opus']);
+    } 
+  })
 }
 
 function autoDetectionTests(manifestUrl) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -605,9 +605,9 @@ function codecTests(manifestUrl, format) {
     const trackList = player.getVariantTracks();
     const audioCodecList = trackList.map(track => track.audioCodec);
     if (manifestUrl == hlsManifestUrl) {
-      expect(audioCodecList).toEqual(['mp4a.40.2']);
+      expect(audioCodecList).not.toContain('opus');
     } else if (manifestUrl == dashManifestUrl) {
-      expect(audioCodecList).toEqual(['opus']);
+      expect(audioCodecList).toContain('opus');
     } 
   })
 }


### PR DESCRIPTION
### Overview 
Addresses [ Issue 18](https://github.com/google/shaka-streamer/issues/18)

- Restrict WebM formats to DASH protocol only, preventing WebM formats in HLS
- Restriction is set via Shaka Packager's "dash_only" flag as per discussion in the [ Issue 18 thread](https://github.com/google/shaka-streamer/issues/18)

### Testing
-  Added and passed unit test
- Tested manually by analyzing command line output and HLS manifest content when "aac" and "opus" audio codecs are specified
-  Ex:
 DASH (contains WebM)
![image](https://user-images.githubusercontent.com/38890251/121139833-0b42c080-c7ee-11eb-84a4-7cc80a5bb6e9.png)
HLS (does NOT contain WebM)
![image](https://user-images.githubusercontent.com/38890251/121139952-2d3c4300-c7ee-11eb-9386-008a6ae6c407.png)

