### PR TITLE
Slight speed up of vp9 encoding

### DIFF
--- a/streamer/transcoder_node.py
+++ b/streamer/transcoder_node.py
@@ -275,6 +275,8 @@ class TranscoderNode(PolitelyWaitOnFinish):
           # resources and speeds up encoding.  This is still not the default
           # setting as of libvpx v1.7.
           '-row-mt', '1',
+          # speeds up encoding, balancing against quality
+          '-speed', '2',
       ]
     elif stream.codec == VideoCodec.AV1:
       args += [


### PR DESCRIPTION
Faster vp9 encoding, whilst still maintaining balance between speed/quality.

In my testing, for a given file, this results in ~20% reduction in encoding time.
The subjective difference in output quality appears negligible.
