### PR TITLE
HTTP url output support

### DIFF
--- a/run_end_to_end_tests.py
+++ b/run_end_to_end_tests.py
@@ -155,7 +155,7 @@ def start():
 
   controller = ControllerNode()
   try:
-    controller.start(OUTPUT_DIR,
+    controller.start(configs['output_location'],
                      configs['input_config'],
                      configs['pipeline_config'],
                      configs['bitrate_config'],
@@ -174,6 +174,12 @@ def start():
         'field_name': e.field_name,
         'field_type': e.field.get_type_name(),
         'message': str(e),
+      })
+      return createCrossOriginResponse(
+          status=418, mimetype='application/json', body=body)
+    elif isinstance(e, RuntimeError):
+      body = json.dumps({
+        'error_type': 'RuntimeError',
       })
       return createCrossOriginResponse(
           status=418, mimetype='application/json', body=body)

--- a/shaka-streamer
+++ b/shaka-streamer
@@ -66,7 +66,8 @@ def main():
                            'upload to.  (Starts with gs:// or s3://)')
   parser.add_argument('-o', '--output',
                       default='output_files',
-                      help='The output folder to write files to. ' +
+                      help='The output folder to write files to, or an HTTP ' +
+                           'or HTTPS URL where files will be PUT.' +
                            'Used even if uploading to cloud storage.')
   parser.add_argument('--skip_deps_check',
                       action='store_true',

--- a/streamer/controller_node.py
+++ b/streamer/controller_node.py
@@ -24,6 +24,7 @@ also want to look at the source code to the command-line front end script
 import os
 import re
 import shutil
+import streamer.util
 import string
 import subprocess
 import sys
@@ -96,7 +97,7 @@ class ControllerNode(object):
 
     return path
 
-  def start(self, output_dir: str,
+  def start(self, output_location: str,
             input_config_dict: Dict[str, Any],
             pipeline_config_dict: Dict[str, Any],
             bitrate_config_dict: Dict[Any, Any] = {},
@@ -135,15 +136,7 @@ class ControllerNode(object):
     if bucket_url:
       # If using cloud storage, make sure the user is logged in and can access
       # the destination, independent of the version check above.
-      CloudNode.check_access(bucket_url)
-
-
-    self._output_dir = output_dir
-    # Check if the directory for outputted Packager files exists, and if it
-    # does, delete it and remake a new one.
-    if os.path.exists(self._output_dir):
-      shutil.rmtree(self._output_dir)
-    os.mkdir(self._output_dir)
+      CloudNode.check_access(bucket_url)    
 
     # Define resolutions and bitrates before parsing other configs.
     bitrate_config = BitrateConfig(bitrate_config_dict)
@@ -157,29 +150,55 @@ class ControllerNode(object):
     self._input_config = InputConfig(input_config_dict)
     self._pipeline_config = PipelineConfig(pipeline_config_dict)
 
+    if not streamer.util.is_url(output_location):
+      # Check if the directory for outputted Packager files exists, and if it
+      # does, delete it and remake a new one.
+      if os.path.exists(output_location):
+        shutil.rmtree(output_location)
+      os.mkdir(output_location)
+    else :
+      # Check some restrictions and other details on HTTP output.
+      if not self._pipeline_config.segment_per_file:
+        raise RuntimeError(
+            'For HTTP PUT uploads, the pipeline segment_per_file setting ' +
+            'must be set to True!')
+
+      if bucket_url:
+        raise RuntimeError(
+            'Cloud bucket upload is incompatible with HTTP PUT support.')
+      
+      if self._input_config.multiperiod_inputs_list:
+        # TODO: Edit Multiperiod input list implementation to support HTTP outputs
+        raise RuntimeError(
+            'Multiperiod input list support is incompatible with HTTP outputs.')
+
+    # Note that we remove the trailing slash from the output location, because
+    # otherwise GCS would create a subdirectory whose name is "".
+    output_location = output_location.rstrip('/')
+
     if self._input_config.inputs:
       # InputConfig contains inputs only.
-      self._append_nodes_for_inputs_list(self._input_config.inputs)
+      self._append_nodes_for_inputs_list(self._input_config.inputs, output_location)
     else:
       # InputConfig contains multiperiod_inputs_list only.
       # Create one Transcoder node and one Packager node for each period.
       for i, singleperiod in enumerate(self._input_config.multiperiod_inputs_list):
         sub_dir_name = 'period_' + str(i)
-        self._append_nodes_for_inputs_list(singleperiod.inputs, sub_dir_name)
+        self._append_nodes_for_inputs_list(singleperiod.inputs, output_location, sub_dir_name)
 
       if self._pipeline_config.streaming_mode == StreamingMode.VOD:
         packager_nodes = [node for node in self._nodes if isinstance(node, PackagerNode)]
         self._nodes.append(PeriodConcatNode(
           self._pipeline_config,
           packager_nodes,
-          self._output_dir))
+          output_location))
 
     if bucket_url:
       cloud_temp_dir = os.path.join(self._temp_dir, 'cloud')
       os.mkdir(cloud_temp_dir)
 
       packager_nodes = [node for node in self._nodes if isinstance(node, PackagerNode)]
-      self._nodes.append(CloudNode(self._output_dir,
+      self._nodes.append(CloudNode(output_location,
                                    bucket_url,
                                    cloud_temp_dir,
                                    packager_nodes,
@@ -190,7 +209,7 @@ class ControllerNode(object):
       
     return self
 
-  def _append_nodes_for_inputs_list(self, inputs: List[Input],
+  def _append_nodes_for_inputs_list(self, inputs: List[Input], output_location: str,
                period_dir: Optional[str] = None) -> None:
     """A common method that creates Transcoder and Packager nodes for a list of Inputs passed to it.
     
@@ -250,17 +269,15 @@ class ControllerNode(object):
     self._nodes.append(TranscoderNode(inputs,
                                       self._pipeline_config,
                                       outputs))
-
-    output_dir = self._output_dir
     
     # If the inputs list was a period in multiperiod_inputs_list, create a nested directory
     # and put that period in it.
     if period_dir:
-      output_dir = os.path.join(output_dir, period_dir)
-      os.mkdir(output_dir)
+      output_location = os.path.join(output_location, period_dir)
+      os.mkdir(output_location)
 
     self._nodes.append(PackagerNode(self._pipeline_config,
-                                    output_dir,
+                                    output_location,
                                     outputs))
 
   def check_status(self) -> ProcessStatus:

--- a/streamer/controller_node.py
+++ b/streamer/controller_node.py
@@ -24,7 +24,6 @@ also want to look at the source code to the command-line front end script
 import os
 import re
 import shutil
-import streamer.util
 import string
 import subprocess
 import sys
@@ -42,6 +41,7 @@ from streamer.packager_node import PackagerNode
 from streamer.pipeline_configuration import PipelineConfig, StreamingMode
 from streamer.transcoder_node import TranscoderNode
 from streamer.periodconcat_node import PeriodConcatNode
+from streamer.util import is_url
 
 
 class ControllerNode(object):
@@ -136,7 +136,7 @@ class ControllerNode(object):
     if bucket_url:
       # If using cloud storage, make sure the user is logged in and can access
       # the destination, independent of the version check above.
-      CloudNode.check_access(bucket_url)    
+      CloudNode.check_access(bucket_url)
 
     # Define resolutions and bitrates before parsing other configs.
     bitrate_config = BitrateConfig(bitrate_config_dict)
@@ -150,7 +150,7 @@ class ControllerNode(object):
     self._input_config = InputConfig(input_config_dict)
     self._pipeline_config = PipelineConfig(pipeline_config_dict)
 
-    if not streamer.util.is_url(output_location):
+    if not is_url(output_location):
       # Check if the directory for outputted Packager files exists, and if it
       # does, delete it and remake a new one.
       if os.path.exists(output_location):

--- a/streamer/controller_node.py
+++ b/streamer/controller_node.py
@@ -156,7 +156,7 @@ class ControllerNode(object):
       if os.path.exists(output_location):
         shutil.rmtree(output_location)
       os.mkdir(output_location)
-    else :
+    else:
       # Check some restrictions and other details on HTTP output.
       if not self._pipeline_config.segment_per_file:
         raise RuntimeError(

--- a/streamer/packager_node.py
+++ b/streamer/packager_node.py
@@ -15,7 +15,6 @@
 """A module that feeds information from two named pipes into shaka-packager."""
 
 import os
-from streamer.util import is_url
 import subprocess
 
 from . import input_configuration
@@ -24,6 +23,7 @@ from . import pipeline_configuration
 
 from streamer.output_stream import OutputStream
 from streamer.pipeline_configuration import EncryptionMode, PipelineConfig
+from streamer.util import is_url
 from typing import List, Optional, Union
 
 # Alias a few classes to avoid repeating namespaces later.

--- a/streamer/packager_node.py
+++ b/streamer/packager_node.py
@@ -15,6 +15,7 @@
 """A module that feeds information from two named pipes into shaka-packager."""
 
 import os
+from streamer.util import is_url
 import subprocess
 
 from . import input_configuration
@@ -33,38 +34,58 @@ StreamingMode = pipeline_configuration.StreamingMode
 
 
 INIT_SEGMENT = {
-  MediaType.AUDIO: '{dir}/audio_{language}_{channels}c_{bitrate}_{codec}_init.{format}',
-  MediaType.VIDEO: '{dir}/video_{resolution_name}_{bitrate}_{codec}_init.{format}',
-  MediaType.TEXT: '{dir}/text_{language}_init.{format}',
+  MediaType.AUDIO: 'audio_{language}_{channels}c_{bitrate}_{codec}_init.{format}',
+  MediaType.VIDEO: 'video_{resolution_name}_{bitrate}_{codec}_init.{format}',
+  MediaType.TEXT: 'text_{language}_init.{format}',
 }
 
 MEDIA_SEGMENT = {
-  MediaType.AUDIO: '{dir}/audio_{language}_{channels}c_{bitrate}_{codec}_$Number$.{format}',
-  MediaType.VIDEO: '{dir}/video_{resolution_name}_{bitrate}_{codec}_$Number$.{format}',
-  MediaType.TEXT: '{dir}/text_{language}_$Number$.{format}',
+  MediaType.AUDIO: 'audio_{language}_{channels}c_{bitrate}_{codec}_$Number$.{format}',
+  MediaType.VIDEO: 'video_{resolution_name}_{bitrate}_{codec}_$Number$.{format}',
+  MediaType.TEXT: 'text_{language}_$Number$.{format}',
 }
 
 SINGLE_SEGMENT = {
-  MediaType.AUDIO: '{dir}/audio_{language}_{channels}c_{bitrate}_{codec}.{format}',
-  MediaType.VIDEO: '{dir}/video_{resolution_name}_{bitrate}_{codec}.{format}',
-  MediaType.TEXT: '{dir}/text_{language}.{format}',
+  MediaType.AUDIO: 'audio_{language}_{channels}c_{bitrate}_{codec}.{format}',
+  MediaType.VIDEO: 'video_{resolution_name}_{bitrate}_{codec}.{format}',
+  MediaType.TEXT: 'text_{language}.{format}',
 }
 
 class SegmentError(Exception):
   """Raise when segment is incompatible with format."""
   pass
 
+def build_path(output_location, sub_path):
+  """Handle annoying edge cases with paths for cloud upload.
+  If a path has two slashes, GCS will create an intermediate directory named "".
+  So we have to be careful in how we construct paths to avoid this.
+  """
+  # ControllerNode should have already stripped trailing slashes from the output
+  # location.
+
+  # Sometimes the segment dir is empty.  This handles that special case.
+  if not sub_path:
+    return output_location
+
+  if is_url(output_location):
+    # Don't use os.path.join, since URLs must use forward slashes and Streamer
+    # could be used on Windows.
+    return output_location + '/' + sub_path
+
+  return os.path.join(output_location, sub_path)
+
 
 class PackagerNode(node_base.PolitelyWaitOnFinish):
 
   def __init__(self,
                pipeline_config: PipelineConfig,
-               output_dir: str,
+               output_location: str,
                output_streams: List[OutputStream]) -> None:
     super().__init__()
     self._pipeline_config: PipelineConfig = pipeline_config
-    self.output_dir: str = output_dir
-    self._segment_dir: str = os.path.join(output_dir, pipeline_config.segment_folder)
+    self.output_location: str = output_location
+    self._segment_dir: str = build_path(
+        output_location, pipeline_config.segment_folder)
     self._output_streams: List[OutputStream] = output_streams
 
   def start(self) -> None:
@@ -140,16 +161,13 @@ class PackagerNode(node_base.PolitelyWaitOnFinish):
       dict['language'] = stream.input.language
 
     if self._pipeline_config.segment_per_file:
-      dict['init_segment'] = stream.fill_template(
-          INIT_SEGMENT[stream.type],
-          dir=self._segment_dir)
-      dict['segment_template'] = stream.fill_template(
-          MEDIA_SEGMENT[stream.type],
-          dir=self._segment_dir)
+      dict['init_segment'] = build_path(
+          self._segment_dir, stream.fill_template(INIT_SEGMENT[stream.type]))
+      dict['segment_template'] = build_path(
+          self._segment_dir, stream.fill_template(MEDIA_SEGMENT[stream.type]))
     else:
-      dict['output'] = stream.fill_template(
-          SINGLE_SEGMENT[stream.type],
-          dir=self._segment_dir)
+      dict['output'] = build_path(
+          self._segment_dir, stream.fill_template(SINGLE_SEGMENT[stream.type]))
 
     if stream.is_dash_only():
       dict['dash_only'] = '1'
@@ -168,7 +186,7 @@ class PackagerNode(node_base.PolitelyWaitOnFinish):
       args += [
           # Generate DASH manifest file.
           '--mpd_output',
-          os.path.join(self.output_dir, self._pipeline_config.dash_output),
+          os.path.join(self.output_location, self._pipeline_config.dash_output),
       ]
     if ManifestFormat.HLS in self._pipeline_config.manifest_format:
       if self._pipeline_config.streaming_mode == StreamingMode.LIVE:
@@ -182,7 +200,7 @@ class PackagerNode(node_base.PolitelyWaitOnFinish):
       args += [
           # Generate HLS playlist file(s).
           '--hls_master_playlist_output',
-          os.path.join(self.output_dir, self._pipeline_config.hls_output),
+          os.path.join(self.output_location, self._pipeline_config.hls_output),
       ]
     return args
 

--- a/streamer/util.py
+++ b/streamer/util.py
@@ -1,0 +1,20 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions used by multiple modules."""
+
+def is_url(output_location: str) -> bool:
+  """Returns True if the output location is a URL."""
+  return (output_location.startswith('http:') or
+      output_location.startswith('https:'))

--- a/streamer/util.py
+++ b/streamer/util.py
@@ -18,4 +18,3 @@ def is_url(output_location: str) -> bool:
   """Returns True if the output location is a URL."""
   return (output_location.startswith('http:') or
       output_location.startswith('https:'))
-      

--- a/streamer/util.py
+++ b/streamer/util.py
@@ -18,3 +18,4 @@ def is_url(output_location: str) -> bool:
   """Returns True if the output location is a URL."""
   return (output_location.startswith('http:') or
       output_location.startswith('https:'))
+      

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -14,7 +14,6 @@
 
 const flaskServerUrl = 'http://localhost:5000/';
 const outputHttpUrl = 'http://0.0.0.0:8080/';
-const cloudUrl = "gs://my_gcs_bucket/folder/";
 const dashManifestUrl = flaskServerUrl + 'output_files/dash.mpd';
 const hlsManifestUrl = flaskServerUrl + 'output_files/hls.m3u8';
 const OUTPUT_DIR = 'output_files/'

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -371,7 +371,7 @@ function errorTests() {
   it('fails when multiperiod_inputs_list is used with a HTTP url output', async () => {
     const inputConfig = {
       'multiperiod_inputs_list': [
-      getBasicInputConfig(),
+        getBasicInputConfig(),
       ],
     };
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 const flaskServerUrl = 'http://localhost:5000/';
-const outputHttpUrl = 'http://0.0.0.0:8080/';
+const outputHttpUrl = 'http://localhost:80/';
 const dashManifestUrl = flaskServerUrl + 'output_files/dash.mpd';
 const hlsManifestUrl = flaskServerUrl + 'output_files/hls.m3u8';
 const OUTPUT_DIR = 'output_files/'
@@ -374,7 +374,6 @@ function errorTests() {
       getBasicInputConfig(),
       ],
     };
-
 
     await expectAsync(startStreamer(inputConfig, minimalPipelineConfig, {}, outputHttpUrl))
         .toBeRejectedWith(jasmine.objectContaining({


### PR DESCRIPTION
Based off of Joey Parrish's [HTTP Upload commit](https://github.com/joeyparrish/shaka-streamer/commit/e3b02679850ee7cf6961d8e5da2f09674f9a07cf) 

## Feature
- Allow users to specify a HTTP url as an output
- Segments and manifests will be uploaded to the specified url via HTTP PUT
- Urls ending with a '/' will have the slash removed to prevent issues with Google Cloud

## Testing
- Added unit tests to check for config compatibility errors, such as specifying an HTTP url output with a "multi_period_input" and with "segment_per_file" set to false

## Shortcomings
- The multi period input list feature is currently structured to use the local file system and does not easily support HTTP uploads. This must be addressed as the multi period input feature continues to evolve, @meryacine. 
- The HTTP upload feature does not make sense if used with a cloud url, and although there is an error check for this, there is no unit test. The cloud url unit test would have required a mock bucket to pass the cloud url validity checks. Because of the work involved in writing a mock bucket and [the future (and hopefully soon) removal of the CloudNode](https://github.com/CaitlinOCallaghan/shaka-streamer/pull/2#discussion_r661819485), it was decided that forgoing this particular unit test was okay. 
