### PR TITLE
Using Enum._missing_ hook to generically handle the hw: variants

### DIFF
--- a/streamer/output_stream.py
+++ b/streamer/output_stream.py
@@ -119,12 +119,12 @@ class VideoOutputStream(OutputStream):
       'resolution_name': self.resolution.get_key(),
       'bitrate': self.get_bitrate(),
       'format': self.codec.get_output_format(),
-      'codec': self.codec.get_base_codec().value,
+      'codec': self.codec.value,
     }
 
   def get_bitrate(self) -> str:
     """Returns the bitrate for this stream."""
-    return self.resolution.bitrates[self.codec.get_base_codec()]
+    return self.resolution.bitrates[self.codec]
 
 
 class TextOutputStream(OutputStream):

--- a/streamer/transcoder_node.py
+++ b/streamer/transcoder_node.py
@@ -242,7 +242,7 @@ class TranscoderNode(PolitelyWaitOnFinish):
             '-flags', '+loop',
         ]
 
-    if stream.codec.get_base_codec() == VideoCodec.H264:  # Software or hardware
+    if stream.codec == VideoCodec.H264:  # Software or hardware
       # Use the "high" profile for HD and up, and "main" for everything else.
       # https://en.wikipedia.org/wiki/Advanced_Video_Coding#Profiles
       if stream.resolution.max_height >= 720:
@@ -258,7 +258,7 @@ class TranscoderNode(PolitelyWaitOnFinish):
           '-profile:v', profile,
       ]
       
-    if stream.codec.get_base_codec() in {VideoCodec.H264, VideoCodec.HEVC}:
+    if stream.codec in {VideoCodec.H264, VideoCodec.HEVC}:
       args += [
           # The only format supported by QT/Apple.
           '-pix_fmt', 'yuv420p',
@@ -267,7 +267,7 @@ class TranscoderNode(PolitelyWaitOnFinish):
          
       ]
 
-    elif stream.codec.get_base_codec() == VideoCodec.VP9:
+    elif stream.codec == VideoCodec.VP9:
       # TODO: Does -preset apply here?
       args += [
           # According to the wiki (https://trac.ffmpeg.org/wiki/Encode/VP9),


### PR DESCRIPTION
This PR removes the `hw:` enum variants, making the enum only for the base codec variants.

If a codec is prefixed with `hw:`, it will be caught in the `_missing_` hook, we will try to know if it can be one of the base variants or not, if it is a base variant we will set the `_hw_acc` to `True` for this codec variant, if not we will fall back the the `super()._missing_` and print the appropriate error message.