### PR TITLE
docs: Adding `shaka-streamer-binaries` to the prerequisites section

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -44,7 +44,7 @@ Features
   * Control output folders and file names
   * Add arbitrary FFmpeg filters for input or output
 
-* Supports generating multi-period VOD content for DASH (also works for HLS)
+* Supports generating multi-period VOD content for DASH and stitched playlists for HLS
 
 Caveat: text processing
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -44,6 +44,7 @@ Features
   * Control output folders and file names
   * Add arbitrary FFmpeg filters for input or output
 
+* Supports generating multi-period VOD content for DASH (also works for HLS)
 
 Caveat: text processing
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -59,12 +60,9 @@ config.
 Platform support
 ----------------
 
-We support common Linux distributions and macOS.
+We support common Linux distributions, macOS and Windows.
 
 Multiple VAAPI devices are not yet supported on Linux.  See `issue #17`_.
-
-Windows is not supported at this time due to our use of ``os.mkfifo``, but we
-are accepting PRs if you’d like to add Windows support. See `issue #8`_.
 
 
 Getting started

--- a/docs/source/prerequisites.rst
+++ b/docs/source/prerequisites.rst
@@ -40,7 +40,7 @@ This can also be installed via ``pip3`` on any platform:
   # To install/upgrade per-user:
   pip3 install --user --upgrade pyyaml
 
-Shaka Streamer binaries (optional)
+Shaka Streamer Binaries (optional)
 ----------------------------------
 
 Shaka Streamer requires the installation of `Shaka Packager`

--- a/docs/source/prerequisites.rst
+++ b/docs/source/prerequisites.rst
@@ -40,6 +40,30 @@ This can also be installed via ``pip3`` on any platform:
   # To install/upgrade per-user:
   pip3 install --user --upgrade pyyaml
 
+Shaka Streamer binaries (optional)
+----------------------------------
+
+Shaka Streamer requires the installation of `Shaka Packager`
+and `FFmpeg`, as it uses them internally.
+
+These binaries can most likely be installed for your platform
+using ``pip3`` through the PyPi package ``shaka-streamer-binaries``.
+
+If you choose to install ``shaka-streamer-binaries``, you won't need to install
+the other two dependencies: `Shaka Packager` and `FFmpeg`.
+
+To install ``shaka-streamer-binaries``:
+
+.. code:: sh
+
+  pip3 install shaka-streamer-binaries
+
+The static `FFmpeg` builds are pulled from here:
+https://github.com/joeyparrish/static-ffmpeg-binaries
+
+The static `Shaka Packager` builds are pulled from here:
+https://github.com/google/shaka-packager
+
 Shaka Packager
 --------------
 

--- a/streamer/input_configuration.py
+++ b/streamer/input_configuration.py
@@ -314,7 +314,7 @@ class Input(configuration.Base):
     return bitrate_configuration.AudioChannelLayout.get_value(self.channel_layout)
 
 class SinglePeriod(configuration.Base):
-  """An object repersenting one optional video stream and multiple audio and text streams"""
+  """An object representing a single period in a multiperiod inputs list."""
 
   inputs = configuration.Field(List[Input], required=True).cast()
 


### PR DESCRIPTION
I think there is nothing to be written about the multiperiod concatenation, using it would be easy given that there is a sample config file for it.