### PR TITLE
Use `avg_frame_rate` instead of `r_frame_rate` when probing a video

### DIFF
--- a/streamer/autodetect.py
+++ b/streamer/autodetect.py
@@ -104,7 +104,7 @@ def get_interlaced(input: Input) -> bool:
 def get_frame_rate(input: Input) -> Optional[float]:
   """Returns the autodetected frame rate of the input."""
 
-  frame_rate_string = _probe(input, 'stream=r_frame_rate')
+  frame_rate_string = _probe(input, 'stream=avg_frame_rate')
   if frame_rate_string is None:
     return None
 


### PR DESCRIPTION
Seems that `r_frame_rate` may involve some calculation when the video has more than one frame rate(mixed frame rates), ffmpeg will try to find the least common multiple of all the different frame rates in the video, which is not the value we want.

To avoid this, we can use `avg_frame_rate` instead. See [this](https://ffmpeg.org/faq.html#AVStream_002er_005fframe_005frate-is-wrong_002c-it-is-much-larger-than-the-frame-rate_002e)

fixes #90 