### PR TITLE
fix(errors): probe whether the input exists or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
    (https://github.com/google/shaka-streamer/pull/88)
  - Require Python 3.6+
  - Require Shaka Packager v2.6+
+ - New shaka-streamer-binaries package for binary dependencies
+   (https://github.com/google/shaka-streamer/issues/60)
+   (https://github.com/google/shaka-streamer/pull/87)
 
 
 ## 0.4.0 (2021-08-26)

--- a/streamer/autodetect.py
+++ b/streamer/autodetect.py
@@ -80,6 +80,13 @@ def _probe(input: Input, field: str) -> Optional[str]:
 
   return output_string
 
+def is_present(input: Input) -> bool:
+  """Returns true if the stream for this input is indeed found.
+
+  If we can't probe this input type, assume it is present."""
+
+  return bool(_probe(input, 'stream=index') or
+              input.input_type in TYPES_WE_CANT_PROBE)
 
 def get_language(input: Input) -> Optional[str]:
   """Returns the autodetected the language of the input."""

--- a/streamer/autodetect.py
+++ b/streamer/autodetect.py
@@ -104,7 +104,7 @@ def get_interlaced(input: Input) -> bool:
 def get_frame_rate(input: Input) -> Optional[float]:
   """Returns the autodetected frame rate of the input."""
 
-  frame_rate_string = _probe(input, 'stream=r_frame_rate')
+  frame_rate_string = _probe(input, 'stream=avg_frame_rate')
   if frame_rate_string is None:
     return None
 

--- a/streamer/input_configuration.py
+++ b/streamer/input_configuration.py
@@ -21,6 +21,21 @@ from . import configuration
 from typing import List, Dict, Any, Optional
 
 
+class InputNotFound(configuration.ConfigError):
+  """An error raised when an input stream is not found."""
+
+  def __init__(self, input):
+    super().__init__(input.__class__, 'track_num',
+                     getattr(input.__class__, 'track_num'))
+    self.input = input
+
+  def __str__(self):
+    return ('In {}, {} track #{} was'
+            ' not found in "{}"').format(self.class_name,
+                                         self.input.media_type.value,
+                                         self.input.track_num,
+                                         self.input.name)
+
 class InputType(enum.Enum):
   FILE = 'file'
   """A track from a file.  Usable only with VOD."""
@@ -194,6 +209,9 @@ class Input(configuration.Base):
     # FIXME: A late import to avoid circular dependency issues between these two
     # modules.
     from . import autodetect
+
+    if not autodetect.is_present(self):
+      raise InputNotFound(self)
 
     def require_field(name: str) -> None:
       """Raise MissingRequiredField if the named field is still missing."""


### PR DESCRIPTION
Probing with `'stream=index'` should return the `track_num` if it existed, and an empty string if the input did not exist.
fixes #89 