### PR TITLE
Fix arbitrary file reading vulnerabilities.

### DIFF
--- a/run_end_to_end_tests.py
+++ b/run_end_to_end_tests.py
@@ -33,6 +33,7 @@ from mypy import api as mypy_api
 from streamer import node_base
 from streamer.controller_node import ControllerNode
 from streamer.configuration import ConfigError
+from werkzeug.utils import secure_filename
 
 OUTPUT_DIR = 'output_files/'
 TEST_DIR = 'test_assets/'
@@ -217,6 +218,7 @@ def stop():
 
 @app.route('/output_files/<path:filename>', methods = ['GET', 'OPTIONS'])
 def send_file(filename):
+  filename = secure_filename(filename)
   if not controller:
     return createCrossOriginResponse(
         status=403, body='Instance already shut down!')


### PR DESCRIPTION
Use `werkzeug.utils.secure_filename` to fix arbitrary file reading vulnerabilities.