### PR TITLE
fix(ci): Fix outdated release infrastructure

### DIFF
--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,6 +1,6 @@
 flask>=3,<4
 mypy>=1,<2
-setuptools>=75
+setuptools>=82
 sphinx>=7,<8
-twine>=5,<6
-wheel>=0.44,<1
+twine>=6.2.0
+wheel>=0.46.3,<1


### PR DESCRIPTION
This should fix a failure to release v1.4.0 automatically via GitHub Actions.

With these changes locally, I was able to complete the failed v1.4.0 release to PyPi by repeating all the steps from the GitHub workflow.  So it should work in the workflow context, too.