### PR TITLE
test: Fix urllib.request import

### DIFF
--- a/run_end_to_end_tests.py
+++ b/run_end_to_end_tests.py
@@ -27,7 +27,7 @@ import sys
 import time
 import threading
 import traceback
-import urllib
+import urllib.request
 
 from mypy import api as mypy_api
 from streamer import node_base


### PR DESCRIPTION
This is meant to fix:

`AttributeError: module 'urllib' has no attribute 'request'`

Which is showing up in CI now.