### PR TITLE
fix: Fix detection of forced subtitles

### DIFF
--- a/streamer/autodetect.py
+++ b/streamer/autodetect.py
@@ -182,4 +182,4 @@ def get_forced_subttitle(input: Input) -> bool:
   if forced_subttitle_string is None:
     return False
 
-  return bool(forced_subttitle_string)
+  return forced_subttitle_string == '1'

--- a/streamer/autodetect.py
+++ b/streamer/autodetect.py
@@ -174,12 +174,12 @@ def get_channel_layout(input: Input) -> Optional[AudioChannelLayoutName]:
 
   return None
 
-def get_forced_subttitle(input: Input) -> bool:
+def get_forced_subtitle(input: Input) -> bool:
   """Returns the forced subtitle value of the input."""
 
-  forced_subttitle_string = _probe(input, 'disposition=forced')
+  forced_subtitle_string = _probe(input, 'disposition=forced')
 
-  if forced_subttitle_string is None:
+  if forced_subtitle_string is None:
     return False
 
   # ffprobe reports disposition flags in compact format (p=0:nk=1) as
@@ -188,4 +188,4 @@ def get_forced_subttitle(input: Input) -> bool:
   # The "forced" disposition field is output as the plain string "1" when
   # forced, and "0" otherwise. We must check for exactly "1" rather than
   # using bool(), which would return True for any non-empty string.
-  return forced_subttitle_string == '1'
+  return forced_subtitle_string == '1'

--- a/streamer/autodetect.py
+++ b/streamer/autodetect.py
@@ -182,4 +182,10 @@ def get_forced_subttitle(input: Input) -> bool:
   if forced_subttitle_string is None:
     return False
 
+  # ffprobe reports disposition flags in compact format (p=0:nk=1) as
+  # pipe-separated values without keys, e.g. for a forced subtitle stream:
+  #   subtitle|2|0|0|0|0|0|0|0|1|0|...
+  # The "forced" disposition field is output as the plain string "1" when
+  # forced, and "0" otherwise. We must check for exactly "1" rather than
+  # using bool(), which would return True for any non-empty string.
   return forced_subttitle_string == '1'

--- a/streamer/input_configuration.py
+++ b/streamer/input_configuration.py
@@ -271,7 +271,7 @@ class Input(configuration.Base):
             self.input_type.value)
         disallow_field('input_type', reason)
       if self.forced_subtitle is None:
-        self.forced_subtitle = autodetect.get_forced_subttitle(self)
+        self.forced_subtitle = autodetect.get_forced_subtitle(self)
 
       # These fields are not supported with text, because we don't process or
       # transcode it.


### PR DESCRIPTION
In Python, the bool() function returns True for any non-empty string. This created a bug where any value provided in the configuration (like "0", "False", or "None") would be evaluated as True simply because the string wasn't empty.

By changing it to == '1', we are implementing a strict check. Now, the subtitle track will only be marked as "forced" if the value is explicitly "1".