### PR TITLE
feat: configure output segment templates

### DIFF
--- a/streamer/output_stream.py
+++ b/streamer/output_stream.py
@@ -14,6 +14,7 @@
 
 """Contains information about each output stream."""
 
+import os
 from streamer.bitrate_configuration import AudioCodec, AudioChannelLayout, VideoCodec, VideoResolution
 from streamer.input_configuration import Input, MediaType
 from streamer.pipe import Pipe
@@ -61,7 +62,20 @@ class OutputStream(object):
       return self.codec.get_output_format() == 'webm'
     return False
 
-  def get_init_seg_file(self) -> Pipe:
+  def _format_custom_template(self, template: str,
+                              number_value: str = '') -> str:
+    """Formats a configured template for one output-file variant."""
+    path_templ = template.format(**self.features)
+    if '$Number$' in path_templ:
+      if not number_value:
+        path_templ = path_templ.replace('_$Number$', '')
+      return path_templ.replace('$Number$', number_value)
+    if number_value:
+      root, extension = os.path.splitext(path_templ)
+      return root + number_value + extension
+    return path_templ
+
+  def get_init_seg_file(self, template: str = '') -> Pipe:
     init_segment = {
       MediaType.AUDIO: ('audio_{language}_{channels}c_{bitrate}'
                         '_{codec}_init.{format}'),
@@ -69,10 +83,13 @@ class OutputStream(object):
                         '_{codec}_init.{format}'),
       MediaType.TEXT: 'text_{language}_init.{format}',
     }
-    path_templ = init_segment[self.type].format(**self.features)
+    if template:
+      path_templ = self._format_custom_template(template, '_init')
+    else:
+      path_templ = init_segment[self.type].format(**self.features)
     return Pipe.create_file_pipe(path_templ, mode='w')
 
-  def get_media_seg_file(self) -> Pipe:
+  def get_media_seg_file(self, template: str = '') -> Pipe:
     media_segment = {
       MediaType.AUDIO: ('audio_{language}_{channels}c_{bitrate}'
                         '_{codec}_$Number$.{format}'),
@@ -80,17 +97,23 @@ class OutputStream(object):
                         '_{codec}_$Number$.{format}'),
       MediaType.TEXT: 'text_{language}_$Number$.{format}',
     }
-    path_templ = media_segment[self.type].format(**self.features)
+    if template:
+      path_templ = self._format_custom_template(template, '$Number$')
+    else:
+      path_templ = media_segment[self.type].format(**self.features)
     return Pipe.create_file_pipe(path_templ, mode='w')
 
-  def get_single_seg_file(self) -> Pipe:
+  def get_single_seg_file(self, template: str = '') -> Pipe:
     single_segment = {
       MediaType.AUDIO: ('audio_{language}_{channels}c_{bitrate}'
                         '_{codec}.{format}'),
       MediaType.VIDEO: 'video_{resolution_name}_{bitrate}_{codec}.{format}',
       MediaType.TEXT: 'text_{language}.{format}',
     }
-    path_templ = single_segment[self.type].format(**self.features)
+    if template:
+      path_templ = self._format_custom_template(template)
+    else:
+      path_templ = single_segment[self.type].format(**self.features)
     return Pipe.create_file_pipe(path_templ, mode='w')
 
   def get_identification(self) -> str:

--- a/streamer/packager_node.py
+++ b/streamer/packager_node.py
@@ -171,9 +171,11 @@ class PackagerNode(node_base.PolitelyWaitOnFinish):
     if stream.input.language and stream.input.language != 'und':
       stream_dict['language'] = stream.input.language
 
+    segment_template = self._pipeline_config.segment_template.get(
+        stream.type.value, '')
     if self._pipeline_config.segment_per_file:
-      init_base = stream.get_init_seg_file().write_end()
-      media_base = stream.get_media_seg_file().write_end()
+      init_base = stream.get_init_seg_file(segment_template).write_end()
+      media_base = stream.get_media_seg_file(segment_template).write_end()
       if suffix:
         init_base = init_base.replace('_init.mp4', f'{suffix}_init.mp4')
         media_base = media_base.replace(
@@ -182,7 +184,7 @@ class PackagerNode(node_base.PolitelyWaitOnFinish):
       stream_dict['segment_template'] = build_path(
           self._segment_dir, media_base)
     else:
-      output_base = stream.get_single_seg_file().write_end()
+      output_base = stream.get_single_seg_file(segment_template).write_end()
       if suffix:
         output_base = output_base.replace('.mp4', f'{suffix}.mp4')
       stream_dict['output'] = build_path(self._segment_dir, output_base)

--- a/streamer/pipeline_configuration.py
+++ b/streamer/pipeline_configuration.py
@@ -22,7 +22,7 @@ import platform
 from . import bitrate_configuration
 from . import configuration
 
-from typing import List
+from typing import Dict, List
 
 
 # A randomly-chosen content ID in hex.
@@ -317,6 +317,17 @@ class PipelineConfig(configuration.Base):
 
   segment_folder = configuration.Field(str, default='').cast()
   """Sub-folder for segment output (or blank for none)."""
+
+  segment_template = configuration.Field(
+      Dict[str, str], default={}).cast()
+  """Optional per-media segment filename templates.
+
+  Keys may be ``audio``, ``video``, and ``text``.  Templates use the same
+  feature names as the built-in filenames (for example ``language``,
+  ``bitrate``, ``codec``, and ``format``).  ``$Number$`` is replaced with the
+  segment number placeholder for per-file output and with ``init`` for the
+  initialization segment.  Omitting a media type keeps its existing default.
+  """
 
   segment_size = configuration.Field(float, default=4).cast()
   """The length of each segment in seconds."""


### PR DESCRIPTION
## Summary

Closes #133 by making per-stream segment filenames configurable while preserving the existing defaults.

The new `PipelineConfig.segment_template` mapping accepts `audio`, `video`, and `text` keys. Templates use the existing feature placeholders and may include `$Number$`; the packager derives initialization and single-file names from the same template. Unconfigured media types keep the current hard-coded layout.

This keeps `segment_folder` and manifest naming unchanged, so existing configurations remain compatible.

## Validation

- `python -m py_compile streamer/pipeline_configuration.py streamer/output_stream.py streamer/packager_node.py`
- Direct checks cover `$Number$` expansion, initialization naming, and single-file naming.
- `git diff --check` passes.

The repository's contributing guide requires AI-assisted commits to include attribution. The commit includes the required `Co-Authored-By` trailer. This contribution was prepared with AI assistance and reviewed before submission.